### PR TITLE
Rename Fido2Storage to Fido2Store

### DIFF
--- a/AspNetCoreIdentityFido2Mfa/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/AspNetCoreIdentityFido2Mfa/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -21,15 +21,15 @@ namespace AspNetCoreIdentityFido2Mfa.Areas.Identity.Pages.Account
     public class LoginModel : PageModel
     {
         private readonly SignInManager<IdentityUser> _signInManager;
-        private readonly Fido2Storage _fido2Storage;
+        private readonly Fido2Store _fido2Store;
         private readonly ILogger<LoginModel> _logger;
 
         public LoginModel(SignInManager<IdentityUser> signInManager,
-            Fido2Storage fido2Storage,
+            Fido2Store fido2Store,
             ILogger<LoginModel> logger)
         {
             _signInManager = signInManager;
-            _fido2Storage = fido2Storage;
+            _fido2Store = fido2Store;
             _logger = logger;
         }
 
@@ -124,7 +124,7 @@ namespace AspNetCoreIdentityFido2Mfa.Areas.Identity.Pages.Account
                 }
                 if (result.RequiresTwoFactor)
                 {
-                    var fido2ItemExistsForUser = await _fido2Storage.GetCredentialsByUserNameAsync(Input.Email);
+                    var fido2ItemExistsForUser = await _fido2Store.GetCredentialsByUserNameAsync(Input.Email);
                     if (fido2ItemExistsForUser.Count > 0)
                     {
                         return RedirectToPage("./LoginFido2Mfa", new { ReturnUrl = returnUrl, Input.RememberMe });

--- a/AspNetCoreIdentityFido2Mfa/Areas/Identity/Pages/Account/Manage/Disable2fa.cshtml.cs
+++ b/AspNetCoreIdentityFido2Mfa/Areas/Identity/Pages/Account/Manage/Disable2fa.cshtml.cs
@@ -16,15 +16,15 @@ namespace AspNetCoreIdentityFido2Mfa.Areas.Identity.Pages.Account.Manage
     {
         private readonly UserManager<IdentityUser> _userManager;
         private readonly ILogger<Disable2faModel> _logger;
-        private readonly Fido2Storage _fido2Storage;
+        private readonly Fido2Store _fido2Store;
 
         public Disable2faModel(
             UserManager<IdentityUser> userManager,
-            Fido2Storage fido2Storage,
+            Fido2Store fido2Store,
             ILogger<Disable2faModel> logger)
         {
             _userManager = userManager;
-            _fido2Storage = fido2Storage;
+            _fido2Store = fido2Store;
             _logger = logger;
         }
 
@@ -60,7 +60,7 @@ namespace AspNetCoreIdentityFido2Mfa.Areas.Identity.Pages.Account.Manage
             }
 
             // remove Fido2 MFA if it exists
-            await _fido2Storage.RemoveCredentialsByUserNameAsync(user.UserName);
+            await _fido2Store.RemoveCredentialsByUserNameAsync(user.UserName);
 
             var disable2faResult = await _userManager.SetTwoFactorEnabledAsync(user, false);
             if (!disable2faResult.Succeeded)

--- a/AspNetCoreIdentityFido2Mfa/Fido2/Fido2Store.cs
+++ b/AspNetCoreIdentityFido2Mfa/Fido2/Fido2Store.cs
@@ -5,11 +5,11 @@ using System.Text;
 
 namespace Fido2Identity;
 
-public class Fido2Storage
+public class Fido2Store
 {
     private readonly ApplicationDbContext _applicationDbContext;
 
-    public Fido2Storage(ApplicationDbContext applicationDbContext)
+    public Fido2Store(ApplicationDbContext applicationDbContext)
     {
         _applicationDbContext = applicationDbContext;
     }

--- a/AspNetCoreIdentityFido2Mfa/Program.cs
+++ b/AspNetCoreIdentityFido2Mfa/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddControllers()
 builder.Services.AddRazorPages();
 
 builder.Services.Configure<Fido2Configuration>(builder.Configuration.GetSection("fido2"));
-builder.Services.AddScoped<Fido2Storage>();
+builder.Services.AddScoped<Fido2Store>();
 // Adds a default in-memory implementation of IDistributedCache.
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession(options =>

--- a/AspNetCoreIdentityFido2Passwordless/Fido2/Fido2Store.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Fido2/Fido2Store.cs
@@ -5,11 +5,11 @@ using System.Text;
 
 namespace Fido2Identity;
 
-public class Fido2Storage
+public class Fido2Store
 {
     private readonly ApplicationDbContext _applicationDbContext;
 
-    public Fido2Storage(ApplicationDbContext applicationDbContext)
+    public Fido2Store(ApplicationDbContext applicationDbContext)
     {
         _applicationDbContext = applicationDbContext;
     }

--- a/AspNetCoreIdentityFido2Passwordless/Program.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Program.cs
@@ -30,7 +30,7 @@ builder.Services.AddControllers()
 builder.Services.AddRazorPages();
 
 builder.Services.Configure<Fido2Configuration>(builder.Configuration.GetSection("fido2"));
-builder.Services.AddScoped<Fido2Storage>();
+builder.Services.AddScoped<Fido2Store>();
 // Adds a default in-memory implementation of IDistributedCache.
 builder.Services.AddDistributedMemoryCache();
 builder.Services.AddSession(options =>


### PR DESCRIPTION
To match with the store names in ASP.NET Core Identity, where the stores are named [`UserStore`](https://github.com/dotnet/aspnetcore/blob/main/src/Identity/EntityFrameworkCore/src/UserStore.cs), `RoleStore`, `UserClaimStore`, `RoleClaimStore`, etc.