### PR TITLE
Rename FidoStoredCredential to FidoCredential

### DIFF
--- a/AspNetCoreIdentityFido2Mfa/Data/ApplicationDbContext.cs
+++ b/AspNetCoreIdentityFido2Mfa/Data/ApplicationDbContext.cs
@@ -11,11 +11,11 @@ public class ApplicationDbContext : IdentityDbContext
     {
     }
 
-    public DbSet<FidoStoredCredential> FidoStoredCredential => Set<FidoStoredCredential>();
+    public DbSet<FidoCredential> FidoCredentials => Set<FidoCredential>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
-        builder.Entity<FidoStoredCredential>().HasKey(m => m.Id);
+        builder.Entity<FidoCredential>().HasKey(m => m.Id);
 
         base.OnModelCreating(builder);
     }

--- a/AspNetCoreIdentityFido2Mfa/Fido2/Fido2Store.cs
+++ b/AspNetCoreIdentityFido2Mfa/Fido2/Fido2Store.cs
@@ -14,42 +14,42 @@ public class Fido2Store
         _applicationDbContext = applicationDbContext;
     }
 
-    public async Task<ICollection<FidoStoredCredential>> GetCredentialsByUserNameAsync(string username)
+    public async Task<ICollection<FidoCredential>> GetCredentialsByUserNameAsync(string username)
     {
-        return await _applicationDbContext.FidoStoredCredential.Where(c => c.UserName == username).ToListAsync();
+        return await _applicationDbContext.FidoCredentials.Where(c => c.UserName == username).ToListAsync();
     }
 
     public async Task RemoveCredentialsByUserNameAsync(string username)
     {
-        var items = await _applicationDbContext.FidoStoredCredential.Where(c => c.UserName == username).ToListAsync();
+        var items = await _applicationDbContext.FidoCredentials.Where(c => c.UserName == username).ToListAsync();
         if (items != null)
         {
             foreach (var fido2Key in items)
             {
-                _applicationDbContext.FidoStoredCredential.Remove(fido2Key);
+                _applicationDbContext.FidoCredentials.Remove(fido2Key);
             };
 
             await _applicationDbContext.SaveChangesAsync();
         }
     }
 
-    public async Task<FidoStoredCredential?> GetCredentialByIdAsync(byte[] id)
+    public async Task<FidoCredential?> GetCredentialByIdAsync(byte[] id)
     {
         var credentialIdString = Base64Url.Encode(id);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString))
             .FirstOrDefaultAsync();
 
         return cred;
     }
 
-    public Task<ICollection<FidoStoredCredential>> GetCredentialsByUserHandleAsync(byte[] userHandle)
+    public Task<ICollection<FidoCredential>> GetCredentialsByUserHandleAsync(byte[] userHandle)
     {
-        return Task.FromResult<ICollection<FidoStoredCredential>>(
+        return Task.FromResult<ICollection<FidoCredential>>(
             _applicationDbContext
-                .FidoStoredCredential.Where(c => c.UserHandle != null && c.UserHandle.SequenceEqual(userHandle))
+                .FidoCredentials.Where(c => c.UserHandle != null && c.UserHandle.SequenceEqual(userHandle))
                 .ToList());
     }
 
@@ -58,7 +58,7 @@ public class Fido2Store
         var credentialIdString = Base64Url.Encode(credentialId);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString)).FirstOrDefaultAsync();
 
         if(cred != null)
@@ -68,10 +68,10 @@ public class Fido2Store
         }
     }
 
-    public async Task AddCredentialToUserAsync(Fido2User user, FidoStoredCredential credential)
+    public async Task AddCredentialToUserAsync(Fido2User user, FidoCredential credential)
     {
         credential.UserId = user.Id;
-        _applicationDbContext.FidoStoredCredential.Add(credential);
+        _applicationDbContext.FidoCredentials.Add(credential);
         await _applicationDbContext.SaveChangesAsync();
     }
 
@@ -80,7 +80,7 @@ public class Fido2Store
         var credentialIdString = Base64Url.Encode(credentialId);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString)).FirstOrDefaultAsync();
 
         if (cred == null || cred.UserId == null)

--- a/AspNetCoreIdentityFido2Mfa/Fido2/FidoStoredCredential.cs
+++ b/AspNetCoreIdentityFido2Mfa/Fido2/FidoStoredCredential.cs
@@ -7,7 +7,7 @@ namespace Fido2Identity;
 /// <summary>
 /// Represents a WebAuthn credential.
 /// </summary>
-public class FidoStoredCredential
+public class FidoCredential
 {
     /// <summary>
     /// Gets or sets the primary key for this user.

--- a/AspNetCoreIdentityFido2Mfa/Fido2/MfaFido2RegisterController.cs
+++ b/AspNetCoreIdentityFido2Mfa/Fido2/MfaFido2RegisterController.cs
@@ -127,7 +127,7 @@ public class MfaFido2RegisterController : Controller
             if(success.Result != null)
             {
                 // 3. Store the credentials in db
-                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoStoredCredential
+                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoCredential
                 {
                     UserName = options.User.Name,
                     Descriptor = new PublicKeyCredentialDescriptor(success.Result.CredentialId),

--- a/AspNetCoreIdentityFido2Mfa/Fido2/PwFido2RegisterController.cs
+++ b/AspNetCoreIdentityFido2Mfa/Fido2/PwFido2RegisterController.cs
@@ -124,7 +124,7 @@ public class PwFido2RegisterController : Controller
             if(success.Result != null)
             {
                 // 3. Store the credentials in db
-                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoStoredCredential
+                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoCredential
                 {
                     UserName = options.User.Name,
                     Descriptor = new PublicKeyCredentialDescriptor(success.Result.CredentialId),

--- a/AspNetCoreIdentityFido2Mfa/Migrations/20210820152613_init_identity.Designer.cs
+++ b/AspNetCoreIdentityFido2Mfa/Migrations/20210820152613_init_identity.Designer.cs
@@ -21,7 +21,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
                 .HasAnnotation("ProductVersion", "5.0.9")
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Fido2Identity.FidoStoredCredential", b =>
+            modelBuilder.Entity("Fido2Identity.FidoCredentials", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -57,7 +57,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("FidoStoredCredential");
+                    b.ToTable("FidoCredentials");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>

--- a/AspNetCoreIdentityFido2Mfa/Migrations/20210820152613_init_identity.cs
+++ b/AspNetCoreIdentityFido2Mfa/Migrations/20210820152613_init_identity.cs
@@ -47,7 +47,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "FidoStoredCredential",
+                name: "FidoCredential",
                 columns: table => new
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
@@ -64,7 +64,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_FidoStoredCredential", x => x.Id);
+                    table.PrimaryKey("PK_FidoCredential", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -231,7 +231,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
                 name: "AspNetUserTokens");
 
             migrationBuilder.DropTable(
-                name: "FidoStoredCredential");
+                name: "FidoCredentials");
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");

--- a/AspNetCoreIdentityFido2Mfa/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/AspNetCoreIdentityFido2Mfa/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -19,7 +19,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
                 .HasAnnotation("ProductVersion", "5.0.9")
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Fido2Identity.FidoStoredCredential", b =>
+            modelBuilder.Entity("Fido2Identity.FidoCredentials", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -55,7 +55,7 @@ namespace AspNetCoreIdentityFido2Mfa.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("FidoStoredCredential");
+                    b.ToTable("FidoCredentials");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>

--- a/AspNetCoreIdentityFido2Passwordless/Data/ApplicationDbContext.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Data/ApplicationDbContext.cs
@@ -11,11 +11,11 @@ public class ApplicationDbContext : IdentityDbContext
     {
     }
 
-    public DbSet<FidoStoredCredential> FidoStoredCredential => Set<FidoStoredCredential>();
+    public DbSet<FidoCredential> FidoCredentials => Set<FidoCredential>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
-        builder.Entity<FidoStoredCredential>().HasKey(m => m.Id);
+        builder.Entity<FidoCredential>().HasKey(m => m.Id);
 
         base.OnModelCreating(builder);
     }

--- a/AspNetCoreIdentityFido2Passwordless/Fido2/Fido2Store.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Fido2/Fido2Store.cs
@@ -14,42 +14,42 @@ public class Fido2Store
         _applicationDbContext = applicationDbContext;
     }
 
-    public async Task<ICollection<FidoStoredCredential>> GetCredentialsByUserNameAsync(string username)
+    public async Task<ICollection<FidoCredential>> GetCredentialsByUserNameAsync(string username)
     {
-        return await _applicationDbContext.FidoStoredCredential.Where(c => c.UserName == username).ToListAsync();
+        return await _applicationDbContext.FidoCredentials.Where(c => c.UserName == username).ToListAsync();
     }
 
     public async Task RemoveCredentialsByUserNameAsync(string username)
     {
-        var items = await _applicationDbContext.FidoStoredCredential.Where(c => c.UserName == username).ToListAsync();
+        var items = await _applicationDbContext.FidoCredentials.Where(c => c.UserName == username).ToListAsync();
         if (items != null)
         {
             foreach (var fido2Key in items)
             {
-                _applicationDbContext.FidoStoredCredential.Remove(fido2Key);
+                _applicationDbContext.FidoCredentials.Remove(fido2Key);
             };
 
             await _applicationDbContext.SaveChangesAsync();
         }
     }
 
-    public async Task<FidoStoredCredential?> GetCredentialByIdAsync(byte[] id)
+    public async Task<FidoCredential?> GetCredentialByIdAsync(byte[] id)
     {
         var credentialIdString = Base64Url.Encode(id);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString))
             .FirstOrDefaultAsync();
 
         return cred;
     }
 
-    public Task<ICollection<FidoStoredCredential>> GetCredentialsByUserHandleAsync(byte[] userHandle)
+    public Task<ICollection<FidoCredential>> GetCredentialsByUserHandleAsync(byte[] userHandle)
     {
-        return Task.FromResult<ICollection<FidoStoredCredential>>(
+        return Task.FromResult<ICollection<FidoCredential>>(
             _applicationDbContext
-                .FidoStoredCredential.Where(c => c.UserHandle != null && c.UserHandle.SequenceEqual(userHandle))
+                .FidoCredentials.Where(c => c.UserHandle != null && c.UserHandle.SequenceEqual(userHandle))
                 .ToList());
     }
 
@@ -58,7 +58,7 @@ public class Fido2Store
         var credentialIdString = Base64Url.Encode(credentialId);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString)).FirstOrDefaultAsync();
 
         if(cred != null)
@@ -68,10 +68,10 @@ public class Fido2Store
         }
     }
 
-    public async Task AddCredentialToUserAsync(Fido2User user, FidoStoredCredential credential)
+    public async Task AddCredentialToUserAsync(Fido2User user, FidoCredential credential)
     {
         credential.UserId = user.Id;
-        _applicationDbContext.FidoStoredCredential.Add(credential);
+        _applicationDbContext.FidoCredentials.Add(credential);
         await _applicationDbContext.SaveChangesAsync();
     }
 
@@ -80,7 +80,7 @@ public class Fido2Store
         var credentialIdString = Base64Url.Encode(credentialId);
         //byte[] credentialIdStringByte = Base64Url.Decode(credentialIdString);
 
-        var cred = await _applicationDbContext.FidoStoredCredential
+        var cred = await _applicationDbContext.FidoCredentials
             .Where(c => c.DescriptorJson != null && c.DescriptorJson.Contains(credentialIdString)).FirstOrDefaultAsync();
 
         if (cred == null || cred.UserId == null)

--- a/AspNetCoreIdentityFido2Passwordless/Fido2/FidoStoredCredential.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Fido2/FidoStoredCredential.cs
@@ -7,7 +7,7 @@ namespace Fido2Identity;
 /// <summary>
 /// Represents a WebAuthn credential.
 /// </summary>
-public class FidoStoredCredential
+public class FidoCredential
 {
     /// <summary>
     /// Gets or sets the primary key for this user.

--- a/AspNetCoreIdentityFido2Passwordless/Fido2/MfaFido2RegisterController.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Fido2/MfaFido2RegisterController.cs
@@ -125,7 +125,7 @@ public class MfaFido2RegisterController : Controller
             if (success.Result != null)
             {
                 // 3. Store the credentials in db
-                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoStoredCredential
+                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoCredential
                 {
                     UserName = options.User.Name,
                     Descriptor = new PublicKeyCredentialDescriptor(success.Result.CredentialId),

--- a/AspNetCoreIdentityFido2Passwordless/Fido2/PwFido2RegisterController.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Fido2/PwFido2RegisterController.cs
@@ -124,7 +124,7 @@ public class PwFido2RegisterController : Controller
             if(success.Result != null)
             {
                 // 3. Store the credentials in db
-                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoStoredCredential
+                await _fido2Store.AddCredentialToUserAsync(options.User, new FidoCredential
                 {
                     UserName = options.User.Name,
                     Descriptor = new PublicKeyCredentialDescriptor(success.Result.CredentialId),

--- a/AspNetCoreIdentityFido2Passwordless/Migrations/20200506090154_init.Designer.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Migrations/20200506090154_init.Designer.cs
@@ -21,7 +21,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Fido2Identity.FidoStoredCredential", b =>
+            modelBuilder.Entity("Fido2Identity.FidoCredentials", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -57,7 +57,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("FidoStoredCredential");
+                    b.ToTable("FidoCredentials");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>

--- a/AspNetCoreIdentityFido2Passwordless/Migrations/20200506090154_init.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Migrations/20200506090154_init.cs
@@ -47,7 +47,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "FidoStoredCredential",
+                name: "FidoCredential",
                 columns: table => new
                 {
                     Id = table.Column<int>(nullable: false)
@@ -64,7 +64,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_FidoStoredCredential", x => x.Id);
+                    table.PrimaryKey("PK_FidoCredential", x => x.Id);
                 });
 
             migrationBuilder.CreateTable(
@@ -231,7 +231,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
                 name: "AspNetUserTokens");
 
             migrationBuilder.DropTable(
-                name: "FidoStoredCredential");
+                name: "FidoCredentials");
 
             migrationBuilder.DropTable(
                 name: "AspNetRoles");

--- a/AspNetCoreIdentityFido2Passwordless/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/AspNetCoreIdentityFido2Passwordless/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -19,7 +19,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
                 .HasAnnotation("Relational:MaxIdentifierLength", 128)
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
-            modelBuilder.Entity("Fido2Identity.FidoStoredCredential", b =>
+            modelBuilder.Entity("Fido2Identity.FidoCredentials", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -55,7 +55,7 @@ namespace AspNetCoreIdentityFido2Passwordless.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("FidoStoredCredential");
+                    b.ToTable("FidoCredentials");
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>


### PR DESCRIPTION
This renames the class `FidoStoredCredential` to `FidoCredential`, and the table `FidoStoredCredential` to `FidoCredentials` (plural).